### PR TITLE
:memo: modify the idField type in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Second array to be compared.
 #### idField
 
 *Required*<br>
-Type: `array`
+Type: `string`
 
 The id field that is used to compare the arrays. Defaults to 'id'.
 


### PR DESCRIPTION
I see the source code that idField must be a string, so modify the doc and want to say thx for you package helping me to solve a big feature.
https://github.com/malcolmvr/diff-arrays-of-objects/blob/master/lib/index.js#L32